### PR TITLE
Sarama offset fix

### DIFF
--- a/multi_elasticsearch.go
+++ b/multi_elasticsearch.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"fmt"
+
 	"golang.org/x/net/context"
 	"gopkg.in/olivere/elastic.v5"
 )
@@ -46,7 +47,7 @@ type ElasticsearchTenancy interface {
 func NewMultiElasticsearch(config *Config, client *elastic.Client, tenancy ElasticsearchTenancy) *MultiElasticsearch {
 	indexName, typeName := tenancy.TenantIndexAndType("tenant")
 	metrics := config.MetricsProvider
-	labelNames := []string{"topicProcessor", "index/type"}
+	labelNames := []string{"topicProcessor", "indexAndType"}
 	labelValues := []string{config.TopicProcessorName, fmt.Sprintf("%s/%s", indexName, typeName)}
 	s := &MultiElasticsearch{
 		config,

--- a/partition_processor.go
+++ b/partition_processor.go
@@ -38,15 +38,19 @@ func getPartitionConsumer(tp *TopicProcessor, consumer sarama.Consumer, pom sara
 	if err != nil {
 		tp.logger.Panic(err)
 	}
-	// nextOffset, _ := pom.NextOffset()
-	// if nextOffset > newestOffset {
-	// 	nextOffset = sarama.OffsetNewest
-	// }
-	tp.logger.Info("===TEST===")
-	tp.logger.Infof("Consuming topic partition %s-%d from offset '%s' (newest offset is '%s')", topic, partition, offsetToString(newestOffset), offsetToString(newestOffset))
+	nextOffset, _ := pom.NextOffset()
+	if nextOffset > newestOffset {
+		nextOffset = sarama.OffsetNewest
+	}
+	tp.logger.Infof("Consuming topic partition %s-%d from offset '%s' (newest offset is '%s')", topic, partition, offsetToString(nextOffset), offsetToString(newestOffset))
 	c, err := consumer.ConsumePartition(topic, int32(partition), newestOffset)
 	if err != nil {
-		tp.logger.Panic(err)
+		tp.logger.Infof("Error on consuming next offset: %s", err)
+		tp.logger.Infof("Consuming topic partition %s-%d from newest offset '%s'", topic, partition, offsetToString(newestOffset))
+		c, err = consumer.ConsumePartition(topic, int32(partition), newestOffset)
+		if err != nil {
+			tp.logger.Panic(err)
+		}
 	}
 	return c
 }

--- a/partition_processor.go
+++ b/partition_processor.go
@@ -42,7 +42,7 @@ func getPartitionConsumer(tp *TopicProcessor, consumer sarama.Consumer, pom sara
 	if nextOffset > newestOffset {
 		nextOffset = sarama.OffsetNewest
 	}
-	tp.logger.Infof("Consuming topic partition %s-%d from offset '%s' (newest offset is '%s')", topic, partition, offsetToString(nextOffset), offsetToString(newestOffset))
+	tp.logger.Infof("Consuming topic partition %s-%d from next offset '%s' (newest offset is '%s')", topic, partition, offsetToString(nextOffset), offsetToString(newestOffset))
 	c, err := consumer.ConsumePartition(topic, int32(partition), newestOffset)
 	if err != nil {
 		tp.logger.Infof("Error on consuming next offset: %s", err)

--- a/partition_processor.go
+++ b/partition_processor.go
@@ -43,7 +43,7 @@ func getPartitionConsumer(tp *TopicProcessor, consumer sarama.Consumer, pom sara
 		nextOffset = sarama.OffsetNewest
 	}
 	tp.logger.Infof("Consuming topic partition %s-%d from next offset '%s' (newest offset is '%s')", topic, partition, offsetToString(nextOffset), offsetToString(newestOffset))
-	c, err := consumer.ConsumePartition(topic, int32(partition), newestOffset)
+	c, err := consumer.ConsumePartition(topic, int32(partition), nextOffset)
 	if err != nil {
 		tp.logger.Infof("Error on consuming next offset: %s", err)
 		tp.logger.Infof("Consuming topic partition %s-%d from newest offset '%s'", topic, partition, offsetToString(newestOffset))

--- a/partition_processor.go
+++ b/partition_processor.go
@@ -38,12 +38,13 @@ func getPartitionConsumer(tp *TopicProcessor, consumer sarama.Consumer, pom sara
 	if err != nil {
 		tp.logger.Panic(err)
 	}
-	nextOffset, _ := pom.NextOffset()
-	if nextOffset > newestOffset {
-		nextOffset = sarama.OffsetNewest
-	}
-	tp.logger.Infof("Consuming topic partition %s-%d from offset '%s' (newest offset is '%s')", topic, partition, offsetToString(nextOffset), offsetToString(newestOffset))
-	c, err := consumer.ConsumePartition(topic, int32(partition), nextOffset)
+	// nextOffset, _ := pom.NextOffset()
+	// if nextOffset > newestOffset {
+	// 	nextOffset = sarama.OffsetNewest
+	// }
+	tp.logger.Info("===TEST===")
+	tp.logger.Infof("Consuming topic partition %s-%d from offset '%s' (newest offset is '%s')", topic, partition, offsetToString(newestOffset), offsetToString(newestOffset))
+	c, err := consumer.ConsumePartition(topic, int32(partition), newestOffset)
 	if err != nil {
 		tp.logger.Panic(err)
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -172,7 +172,7 @@
 		},
 		{
 			"checksumSHA1": "WNUXk4QuaSU7sTkz3qD8aKeMino=",
-				"path": "gopkg.in/olivere/elastic.v5",
+			"path": "gopkg.in/olivere/elastic.v5",
 			"revision": "5f2bc471137b3a0574c35c3f33ee9e644e41c9f9",
 			"revisionTime": "2017-04-14T09:06:51Z"
 		},


### PR DESCRIPTION
Sometimes sarama partition offset manager returns next offset that already does not exisit itn topic. in that case, I suggest to read from newest offset instead.

Also, "index/type" is not a correct label for prometheus.