### PR TITLE
Add `Flush()` to Sender

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -11,10 +11,11 @@ import (
 // and resumes processing.
 type Sender interface {
 
-	// Send adds a message to an batch that is send when Process returns or when Flush is called
+	// Send appends a message to a slice held by the sender instance.
+	// These messages are sent in bulk when Process() returns or when Flush() is called.
 	Send(msg *sarama.ProducerMessage)
 
-	// Flush immediately sends the currently batched messages and empties the batch
+	// Flush immediately sends all messages held in the sender slice in bulk, and empties the slice. See Send() above.
 	Flush() error
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -172,7 +172,7 @@
 		},
 		{
 			"checksumSHA1": "WNUXk4QuaSU7sTkz3qD8aKeMino=",
-				"path": "gopkg.in/olivere/elastic.v5",
+			"path": "gopkg.in/olivere/elastic.v5",
 			"revision": "5f2bc471137b3a0574c35c3f33ee9e644e41c9f9",
 			"revisionTime": "2017-04-14T09:06:51Z"
 		},


### PR DESCRIPTION
Flush() allows the user to send the messages to the output topic before closing the main process. For example if you want to perform some action after producing the message but before committing the offsets.