### PR TITLE
Export NoopMetricsProvider

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ func (config *Config) setDefaults() {
 		config.Logger = NewBasicLogger(false)
 	}
 	if config.MetricsProvider == nil {
-		config.MetricsProvider = &noopMetricsProvider{}
+		config.MetricsProvider = &NoopMetricsProvider{}
 	}
 	if config.MetricsUpdateInterval == 0 {
 		config.MetricsUpdateInterval = 15 * time.Second

--- a/elasticsearch_test.go
+++ b/elasticsearch_test.go
@@ -158,7 +158,7 @@ func init() {
 	config := &Config{
 		TopicProcessorName: "test",
 		Logger:             &noopLogger{},
-		MetricsProvider:    &noopMetricsProvider{},
+		MetricsProvider:    &NoopMetricsProvider{},
 	}
 	url := fmt.Sprintf("http://%s:9200", getCIHost())
 	client, err := elastic.NewClient(

--- a/multi_elasticsearch_test.go
+++ b/multi_elasticsearch_test.go
@@ -20,7 +20,7 @@ func TestMultiElasticsearch(t *testing.T) {
 	config := &Config{
 		TopicProcessorName: "test",
 		Logger:             &noopLogger{},
-		MetricsProvider:    &noopMetricsProvider{},
+		MetricsProvider:    &NoopMetricsProvider{},
 	}
 	url := fmt.Sprintf("http://%s:9200", getCIHost())
 	client, err := elastic.NewClient(
@@ -38,7 +38,7 @@ func TestMultiElasticsearch_PutAll_GetAll(t *testing.T) {
 	config := &Config{
 		TopicProcessorName: "test",
 		Logger:             &noopLogger{},
-		MetricsProvider:    &noopMetricsProvider{},
+		MetricsProvider:    &NoopMetricsProvider{},
 	}
 	url := fmt.Sprintf("http://%s:9200", getCIHost())
 	client, err := elastic.NewClient(

--- a/multi_redis_test.go
+++ b/multi_redis_test.go
@@ -12,7 +12,7 @@ func TestMultiRedis(t *testing.T) {
 	config := &Config{
 		TopicProcessorName: "test",
 		Logger:             &noopLogger{},
-		MetricsProvider:    &noopMetricsProvider{},
+		MetricsProvider:    &NoopMetricsProvider{},
 	}
 	url := fmt.Sprintf("redis://%s:6379", getCIHost())
 	conn, err := redis.DialURL(url)
@@ -27,7 +27,7 @@ func TestMultiRedis_PutAll_GetAll(t *testing.T) {
 	config := &Config{
 		TopicProcessorName: "test",
 		Logger:             &noopLogger{},
-		MetricsProvider:    &noopMetricsProvider{},
+		MetricsProvider:    &NoopMetricsProvider{},
 	}
 	url := fmt.Sprintf("redis://%s:6379", getCIHost())
 	conn, err := redis.DialURL(url)

--- a/noop_metrics.go
+++ b/noop_metrics.go
@@ -12,16 +12,21 @@ func (m *noopMetric) Add(value float64, labelValues ...string) {}
 
 func (m *noopMetric) Observe(value float64, labelValues ...string) {}
 
-type noopMetricsProvider struct{}
+// NoopMetricsProvider is a dummy implementation of MetricsProvider that does nothing.
+// Useful for testing, not recommended in production.
+type NoopMetricsProvider struct{}
 
-func (m *noopMetricsProvider) NewCounter(name string, help string, labelNames ...string) Counter {
+// NewCounter creates a new no-op Counter
+func (m *NoopMetricsProvider) NewCounter(name string, help string, labelNames ...string) Counter {
 	return &noopMetric{len(labelNames)}
 }
 
-func (m *noopMetricsProvider) NewGauge(name string, help string, labelNames ...string) Gauge {
+// NewGauge creates a new no-op Gauge
+func (m *NoopMetricsProvider) NewGauge(name string, help string, labelNames ...string) Gauge {
 	return &noopMetric{len(labelNames)}
 }
 
-func (m *noopMetricsProvider) NewSummary(name string, help string, labelNames ...string) Summary {
+// NewSummary creates a new no-op Summary
+func (m *NoopMetricsProvider) NewSummary(name string, help string, labelNames ...string) Summary {
 	return &noopMetric{len(labelNames)}
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -118,7 +118,7 @@ func init() {
 	config := &Config{
 		TopicProcessorName: "test",
 		Logger:             &noopLogger{},
-		MetricsProvider:    &noopMetricsProvider{},
+		MetricsProvider:    &NoopMetricsProvider{},
 	}
 	url := fmt.Sprintf("redis://%s:6379", getCIHost())
 	conn, err := redis.DialURL(url)


### PR DESCRIPTION
NoopMetricsProvider is a dummy implementation of MetricsProvider that does nothing.
Useful for testing, not recommended in production.