### PR TITLE
Allow multiple `Close()` calls on TopicProcessor

### DIFF
--- a/topic_processor_test.go
+++ b/topic_processor_test.go
@@ -384,6 +384,7 @@ func populateFictionAndCharactersTopic() int {
 		}
 	}
 	topicProcessor.Close()
+	topicProcessor.Close() // ensure we can close twice
 	return sendCount
 }
 


### PR DESCRIPTION
`TopicProcessor` used to panic because it tried to close an already closed channel. With this change it first checks if the channel was already closed and will not try to close it twice.